### PR TITLE
update(fix): Pick top-level json values from response's json object

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -586,7 +586,7 @@ class ShowOutputModal extends Modal {
 		};
 
 		const parseAndCreate = (data: object) => (key: string) => {
-			const value = DataResponse.includes("->") ? nestedValue(data, key) : data[key];
+			const value = DataResponse.includes("->") ? nestedValue(data, key) : data.json[key];
 			contentEl.createEl('b', { text: key + " : " + JSON.stringify(value, null, 2) });
 		};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -586,8 +586,8 @@ class ShowOutputModal extends Modal {
 		};
 
 		const parseAndCreate = (data: object) => (key: string) => {
-			const value = DataResponse.includes("->") ? nestedValue(data, key) : data.json[key];
-			contentEl.createEl('b', { text: key + " : " + JSON.stringify(value, null, 2) });
+			const value = DataResponse.includes("->") ? nestedValue(data, key) : data.json?.[key];
+			contentEl.createEl('b', { text: `${key} : ${JSON.stringify(value, null, 2)}` });
 		};
 
 		const requestOptions = {


### PR DESCRIPTION
Hello, this looked like a bug to me when executing requests pre-configured in plugin settings. I'd be glad if you take a look and accept this fix. Thanks!