### PR TITLE
docs: replace dead api.coincap.io example in usecase pages

### DIFF
--- a/docs/docs/en/usecase/index.md
+++ b/docs/docs/en/usecase/index.md
@@ -32,12 +32,12 @@ Rendered output will look like this:
 
 ~~~makdown
 ```req 
-url: https://api.coincap.io/v2/rates/bitcoin
-show: $.data.rateUsd
+url: https://api.coinpaprika.com/v1/tickers/btc-bitcoin
+show: $.quotes.USD.price
 ```
 ~~~
 
-> 64992.8972508856324769
+> 64149.230100840585
 
 ## Get the weather
 

--- a/docs/docs/es/usecase/index.md
+++ b/docs/docs/es/usecase/index.md
@@ -32,12 +32,12 @@ La salida renderizada se verá así:
 
 ~~~makdown
 ```req 
-url: https://api.coincap.io/v2/rates/bitcoin
-show: $.data.rateUsd
+url: https://api.coinpaprika.com/v1/tickers/btc-bitcoin
+show: $.quotes.USD.price
 ```
 ~~~
 
-> 64992.8972508856324769
+> 64149.230100840585
 
 ## Obtener el clima
 

--- a/docs/docs/zh/usecase/index.md
+++ b/docs/docs/zh/usecase/index.md
@@ -32,12 +32,12 @@ ID 是 `$=dv.el("span", JSON.parse(localStorage.getItem("req-test")).id, { cls: 
 
 ~~~makdown
 ```req 
-url: https://api.coincap.io/v2/rates/bitcoin
-show: $.data.rateUsd
+url: https://api.coinpaprika.com/v1/tickers/btc-bitcoin
+show: $.quotes.USD.price
 ```
 ~~~
 
-> 64992.8972508856324769
+> 64149.230100840585
 
 ## 获取天气信息
 


### PR DESCRIPTION
## Description
The Bitcoin price example in the usecase docs points at api.coincap.io, which no longer resolves (curl: Could not resolve host), so the snippet silently returns nothing. This swaps it for the keyless CoinPaprika ticker endpoint and adjusts the JSONPath to $.quotes.USD.price. The example is mirrored in the en, es and zh pages, so the same three-line fix is applied to each.

## Type of Change
- [x] Documentation update

## Testing
Verified the new endpoint and JSONPath against the live response using jsonpath-plus, the same library the plugin uses. The sample output in the docs is the actual value the call returned. Also confirmed the old host no longer resolves.

## Checklist
- [x] Docs-only change, no code touched
- [x] Same fix applied to all three language mirrors (en, es, zh)